### PR TITLE
Add keystore password option, and clarify SSL options

### DIFF
--- a/lib/logstash/plugin_mixins/http_client.rb
+++ b/lib/logstash/plugin_mixins/http_client.rb
@@ -110,7 +110,7 @@ module LogStash::PluginMixins::HttpClient
       c[:ssl][:ca_file] = @cacert
     end
 
-    if (@truststore)
+    if @truststore
       c[:ssl].merge!(
         :truststore => @truststore,
         :truststore_type => @truststore_type
@@ -122,14 +122,14 @@ module LogStash::PluginMixins::HttpClient
       end
     end
 
-    if (@keystore)
+    if @keystore
       c[:ssl].merge!(
         :keystore => @keystore,
         :keystore_type => @keystore_type
       )
 
       # JKS files have optional passwords if programatically created
-      if (keystore_password)
+      if keystore_password
         c[:ssl].merge!(keystore_password: @keystore_password.value)
       end
     end

--- a/logstash-mixin-http_client.gemspec
+++ b/logstash-mixin-http_client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-http_client'
-  s.version         = '2.0.0'
+  s.version         = '2.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "AWS mixins to provide a unified interface for Amazon Webservice"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This fixes the issue brought up in this discuss thread https://discuss.elastic.co/t/does-http-poller-handle-https/28864 .

This adds the needed `keystore` option and friends, as well as grouping the SSL options together to make them less confusing.