### PR TITLE
Default to one retry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: ruby
+cache: bundler
+rvm:
+- jruby-1.7.22
+script: bundle exec rspec spec && bundle exec rspec spec --tag integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+# 2.1.0
+ * Default `automatic_retries` to 1 to fix connections to hosts with broken keepalive
+ * Add `non_idempotent_retries` option
+# 2.0.0
+ * Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
- - Dependency on logstash-core update to 2.0
-
+ * Dependency on logstash-core update to 2.0
 # 1.0.2
   * Add 'verify_cert' config option
 # 1.0.1

--- a/lib/logstash/plugin_mixins/http_client.rb
+++ b/lib/logstash/plugin_mixins/http_client.rb
@@ -33,11 +33,17 @@ module LogStash::PluginMixins::HttpClient
     # Max number of concurrent connections to a single host. Defaults to `25`
     config :pool_max_per_route, :validate => :number, :default => 25
 
-    # Turn this on to enable HTTP keepalive support
+    # Turn this on to enable HTTP keepalive support. We highly recommend setting `automatic_retries` to at least
+    # one with this to fix interactions with broken keepalive implementations.
     config :keepalive, :validate => :boolean, :default => true
 
-    # How many times should the client retry a failing URL? Default is `0`
-    config :automatic_retries, :validate => :number, :default => 0
+    # How many times should the client retry a failing URL? We highly recommend NOT setting this value
+    # to zero if keepalive is enabled. Some servers incorrectly end keepalives early requiring a retry!
+    # Note, `retry_non_idempotent` is set only GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
+    config :automatic_retries, :validate => :number, :default => 1
+
+    # If `automatic_retries` is enabled this will cause non-idempotent HTTP verbs (such as POST) to be retried.
+    config :retry_non_idempotent, :validate => :boolean, :default => false
 
     # Set this to false to disable SSL/TLS certificate validation
     # Note: setting this to false is generally considered insecure!
@@ -91,6 +97,7 @@ module LogStash::PluginMixins::HttpClient
       request_timeout: @request_timeout,
       follow_redirects: @follow_redirects,
       automatic_retries: @automatic_retries,
+      retry_non_idempotent: @retry_non_idempotent,
       pool_max: @pool_max,
       pool_max_per_route: @pool_max_per_route,
       cookies: @cookies,

--- a/lib/logstash/plugin_mixins/http_client.rb
+++ b/lib/logstash/plugin_mixins/http_client.rb
@@ -37,9 +37,9 @@ module LogStash::PluginMixins::HttpClient
     # one with this to fix interactions with broken keepalive implementations.
     config :keepalive, :validate => :boolean, :default => true
 
-    # How many times should the client retry a failing URL? We highly recommend NOT setting this value
+    # How many times should the client retry a failing URL. We highly recommend NOT setting this value
     # to zero if keepalive is enabled. Some servers incorrectly end keepalives early requiring a retry!
-    # Note, `retry_non_idempotent` is set only GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
+    # Note: if `retry_non_idempotent` is set only GET, HEAD, PUT, DELETE, OPTIONS, and TRACE requests will be retried.
     config :automatic_retries, :validate => :number, :default => 1
 
     # If `automatic_retries` is enabled this will cause non-idempotent HTTP verbs (such as POST) to be retried.

--- a/logstash-mixin-http_client.gemspec
+++ b/logstash-mixin-http_client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-http_client'
-  s.version         = '2.0.3'
+  s.version         = '2.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "AWS mixins to provide a unified interface for Amazon Webservice"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
As documented in https://github.com/logstash-plugins/logstash-input-http_poller/issues/39 some services have broken keepalive behavior. This patch adds functionality to address that issue by leaving keepalive no, but retrying requests at least once by default.

This also adds a .travis.yml to aid in the review of this PR.