### PR TITLE
Bump manticore to 0.5.2 to support #close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.2.0
+ * Bump manticore version to be at least 0.5.2 for #close support
 # 2.1.0
  * Default `automatic_retries` to 1 to fix connections to hosts with broken keepalive
  * Add `non_idempotent_retries` option

--- a/logstash-mixin-http_client.gemspec
+++ b/logstash-mixin-http_client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-http_client'
-  s.version         = '2.1.0'
+  s.version         = '2.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "AWS mixins to provide a unified interface for Amazon Webservice"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'manticore', '>= 0.4.1'
+  s.add_runtime_dependency 'manticore', '>= 0.5.2', '< 1.0.0'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'stud'


### PR DESCRIPTION
This will let us properly shutdown the client in plugins that use it