### PR TITLE
Allow configuration of validate_after_inactivity + use a better default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.2.1
+ * Use a superior 'validate_after_inactivity' default of 200ms to force more frequent checks for broken keepalive situations
 # 2.2.0
  * Bump manticore version to be at least 0.5.2 for #close support
 # 2.1.0

--- a/lib/logstash/plugin_mixins/http_client.rb
+++ b/lib/logstash/plugin_mixins/http_client.rb
@@ -45,6 +45,13 @@ module LogStash::PluginMixins::HttpClient
     # If `automatic_retries` is enabled this will cause non-idempotent HTTP verbs (such as POST) to be retried.
     config :retry_non_idempotent, :validate => :boolean, :default => false
 
+    # How long to wait before checking if the connection is stale before executing a request on a connection using keepalive.
+    # # You may want to set this lower, possibly to 0 if you get connection errors regularly
+    # Quoting the Apache commons docs (this client is based Apache Commmons):
+    # 'Defines period of inactivity in milliseconds after which persistent connections must be re-validated prior to being leased to the consumer. Non-positive value passed to this method disables connection validation. This check helps detect connections that have become stale (half-closed) while kept inactive in the pool.'
+    # See https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[these docs for more info]
+    config :validate_after_inactivity, :validate => :number, :default => 200
+
     # Set this to false to disable SSL/TLS certificate validation
     # Note: setting this to false is generally considered insecure!
     config :ssl_certificate_validation, :validate => :boolean, :default => true
@@ -98,6 +105,7 @@ module LogStash::PluginMixins::HttpClient
       follow_redirects: @follow_redirects,
       automatic_retries: @automatic_retries,
       retry_non_idempotent: @retry_non_idempotent,
+      check_connection_timeout: @validate_after_inactivity,
       pool_max: @pool_max,
       pool_max_per_route: @pool_max_per_route,
       cookies: @cookies,

--- a/logstash-mixin-http_client.gemspec
+++ b/logstash-mixin-http_client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-http_client'
-  s.version         = '2.2.0'
+  s.version         = '2.2.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "AWS mixins to provide a unified interface for Amazon Webservice"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-mixin-http_client.gemspec
+++ b/logstash-mixin-http_client.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
+  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'manticore', '>= 0.5.2', '< 1.0.0'
 

--- a/spec/plugin_mixin/http_client_spec.rb
+++ b/spec/plugin_mixin/http_client_spec.rb
@@ -37,7 +37,7 @@ describe LogStash::PluginMixins::HttpClient do
     end
 
     if type == :jks
-      let(:store_password) { conf["#{key}_password"].value}
+      let(:store_password) { conf["#{key}_password"] }
       let(:store_type) { conf["#{key}_type"]}
 
       it "should set the bundle password" do

--- a/spec/plugin_mixin/http_client_spec.rb
+++ b/spec/plugin_mixin/http_client_spec.rb
@@ -74,6 +74,17 @@ describe LogStash::PluginMixins::HttpClient do
     end
   end
 
+  describe "with a custom validate_after_activity" do
+    subject { Dummy.new(client_config).send(:client_config) }
+
+    let(:check_timeout) { 20 }
+    let(:client_config) { basic_config.merge("validate_after_inactivity" => check_timeout )}
+
+    it "should properly set the correct manticore option" do
+      expect(subject[:check_connection_timeout]).to eql(check_timeout)
+    end
+  end
+
   describe "with a custom keystore" do
     let(:file) { Stud::Temporary.file }
     let(:path) { file.path }


### PR DESCRIPTION
The manticore default was 15000ms which is quite long, hopefully lowering it to 200ms fixes most user problems.

Fixes https://github.com/logstash-plugins/logstash-output-http/issues/20