### PR TITLE
Fix broken ssl_certificate_validation flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.2.4
+  - Fix 'ssl_certificate_validation' option to actually let you disable cert validation
 # 2.2.3
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
 # 2.2.2

--- a/lib/logstash/plugin_mixins/http_client.rb
+++ b/lib/logstash/plugin_mixins/http_client.rb
@@ -109,8 +109,7 @@ module LogStash::PluginMixins::HttpClient
       pool_max: @pool_max,
       pool_max_per_route: @pool_max_per_route,
       cookies: @cookies,
-      keepalive: @keepalive,
-      verify: @ssl_certificate_validation
+      keepalive: @keepalive
     }
 
     if @proxy
@@ -120,7 +119,7 @@ module LogStash::PluginMixins::HttpClient
         @proxy
     end
 
-    c[:ssl] = {}
+    c[:ssl] = {verify: @ssl_certificate_validation}
     if @cacert
       c[:ssl][:ca_file] = @cacert
     end

--- a/logstash-mixin-http_client.gemspec
+++ b/logstash-mixin-http_client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-http_client'
-  s.version         = '2.2.3'
+  s.version         = '2.2.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "AWS mixins to provide a unified interface for Amazon Webservice"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/plugin_mixin/http_client_spec.rb
+++ b/spec/plugin_mixin/http_client_spec.rb
@@ -137,5 +137,25 @@ describe LogStash::PluginMixins::HttpClient do
       include_examples("raising a configuration error")
     end
 
+    describe "ssl certificate validation" do
+      subject { Dummy.new(conf).send(:client_config) }
+
+      context "when set to true" do
+        let(:conf) { basic_config.merge("ssl_certificate_validation" => true)}
+
+        it "should set [:ssl][:verify] to true" do
+          expect(subject[:ssl][:verify]).to eql(true)
+        end
+      end
+
+      context "when set to false" do
+        let(:conf) { basic_config.merge("ssl_certificate_validation" => false)}
+
+        it "should set [:ssl][:verify] to true" do
+          expect(subject[:ssl][:verify]).to eql(false)
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
The ssl certficate verification option was accidentally a noop. This fixes that. 

Fixes https://github.com/logstash-plugins/logstash-input-http_poller/issues/48