### PR TITLE
Obsolete ssl_certificate_verification option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.0
+  - Obsolete ssl_certificate_verify option that didn't actually work
+
 ## 4.0.3
   - Raise configuration error when user supplies a trust/keystore without a password
 

--- a/lib/logstash/plugin_mixins/http_client.rb
+++ b/lib/logstash/plugin_mixins/http_client.rb
@@ -52,9 +52,7 @@ module LogStash::PluginMixins::HttpClient
     # See https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[these docs for more info]
     config :validate_after_inactivity, :validate => :number, :default => 200
 
-    # Set this to false to disable SSL/TLS certificate validation
-    # Note: setting this to false is generally considered insecure!
-    config :ssl_certificate_validation, :validate => :boolean, :default => true
+    config :ssl_certificate_validation, :obsolete => "This option did not work in a meaningful way and has been removed! Please use the correct truststore"
 
     # If you need to use a custom X.509 CA (.pem certs) specify the path to that here
     config :cacert, :validate => :path
@@ -119,7 +117,7 @@ module LogStash::PluginMixins::HttpClient
         @proxy
     end
 
-    c[:ssl] = {verify: @ssl_certificate_validation}
+    c[:ssl] = {}
     if @cacert
       c[:ssl][:ca_file] = @cacert
     end

--- a/logstash-mixin-http_client.gemspec
+++ b/logstash-mixin-http_client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-http_client'
-  s.version         = '4.0.3'
+  s.version         = '5.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "AWS mixins to provide a unified interface for Amazon Webservice"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/plugin_mixin/http_client_spec.rb
+++ b/spec/plugin_mixin/http_client_spec.rb
@@ -148,26 +148,5 @@ describe LogStash::PluginMixins::HttpClient do
 
       include_examples("raising a configuration error")
     end
-
-    describe "ssl certificate validation" do
-      subject { Dummy.new(conf).send(:client_config) }
-
-      context "when set to true" do
-        let(:conf) { basic_config.merge("ssl_certificate_validation" => true)}
-
-        it "should set [:ssl][:verify] to true" do
-          expect(subject[:ssl][:verify]).to eql(true)
-        end
-      end
-
-      context "when set to false" do
-        let(:conf) { basic_config.merge("ssl_certificate_validation" => false)}
-
-        it "should set [:ssl][:verify] to true" do
-          expect(subject[:ssl][:verify]).to eql(false)
-        end
-      end
-    end
-
   end
 end


### PR DESCRIPTION
This completely removes this option which didn't work anyway.

Currently trying to disable ssl verification will still give you errors and warnings.

This is possible to fix but there is added complexity here since manticore does not support the right hooks into Apache HC to do this properly (https://github.com/cheald/manticore/issues/53).

For the time being it is best to just obsolete this option so as not to confuse people.