### PR TITLE
Add auth configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ config :proxy
 config :client_cert, :validate => :path
 # If you'd like to use a client certificate (note, most people don't want this) set the path to the x509 key here
 config :client_key, :validate => :path
+
+# If you'd like to use authentication. Options available include:
+#
+# user     - username to be used
+# password - password to be used
+# eager    - eagerly offer the Authorization header before the server challenges for it
+config :auth
 ```
 
 ## Documentation

--- a/lib/logstash/plugin_mixins/http_client.rb
+++ b/lib/logstash/plugin_mixins/http_client.rb
@@ -94,6 +94,13 @@ module LogStash::PluginMixins::HttpClient
     # 2. Proxy host in form: `{host => "proxy.org", port => 80, scheme => 'http', user => 'username@host', password => 'password'}`
     # 3. Proxy host in form: `{url =>  'http://proxy.org:1234', user => 'username@host', password => 'password'}`
     config :proxy
+
+    # If you'd like to use authentication. Options available include:
+    #
+    # user     - username to be used
+    # password - password to be used
+    # eager    - eagerly offer the Authorization header before the server challenges for it
+    config :auth
   end
 
   public
@@ -117,6 +124,11 @@ module LogStash::PluginMixins::HttpClient
       c[:proxy] = @proxy.is_a?(Hash) ?
         @proxy.reduce({}) {|memo,(k,v)| memo[k.to_sym] = v; memo} :
         @proxy
+    end
+
+    if @auth
+      # Symbolize keys if necessary
+      c[:auth] = @auth.reduce({}) {|memo,(k,v)| memo[k.to_sym] = v; memo}
     end
 
     c[:ssl] = {verify: @ssl_certificate_validation}


### PR DESCRIPTION
Added support for passing in auth configs to be funneled to manticore. I got the params from [manticore's docs](https://github.com/cheald/manticore/blob/v0.6.0/lib/manticore/client.rb#L22-L26).

If there are any changes that I need to do, just let me know!
