### PR TITLE
Brin back ssl_certificate_verify as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.2.0
+  - Make ssl_certificate_verify deprecated, not obsolete. We don't want
+    to break compat across major logstash versions
+
 # 5.1.0
   - Add user / password options for HTTP auth
 

--- a/lib/logstash/plugin_mixins/http_client.rb
+++ b/lib/logstash/plugin_mixins/http_client.rb
@@ -52,7 +52,7 @@ module LogStash::PluginMixins::HttpClient
     # See https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[these docs for more info]
     config :validate_after_inactivity, :validate => :number, :default => 200
 
-    config :ssl_certificate_validation, :obsolete => "This option did not work in a meaningful way and has been removed! Please use the correct truststore"
+    config :ssl_certificate_validation, :deprecated => "This never worked correctly and is now deprecated and a noop"
 
     # If you need to use a custom X.509 CA (.pem certs) specify the path to that here
     config :cacert, :validate => :path

--- a/logstash-mixin-http_client.gemspec
+++ b/logstash-mixin-http_client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-http_client'
-  s.version         = '5.1.0'
+  s.version         = '5.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "AWS mixins to provide a unified interface for Amazon Webservice"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This brings back the option though it remains a noop. We want to use the
5.x version of this mixin in other plugins but we don't want to break
our contract not to break non-deprecated configs in non-major versions.

This option is still a noop. Since it never worked correctly there's no
reason to replicate the broken functionality.

