### PR TITLE
mark ssl_certificate_verify as obsolete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 6.0.0
+  - Breaking: mark ssl_certificate_verify as obsolete
+
 # 5.2.0
   - Make ssl_certificate_verify deprecated, not obsolete. We don't want
     to break compat across major logstash versions

--- a/lib/logstash/plugin_mixins/http_client.rb
+++ b/lib/logstash/plugin_mixins/http_client.rb
@@ -52,7 +52,7 @@ module LogStash::PluginMixins::HttpClient
     # See https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[these docs for more info]
     config :validate_after_inactivity, :validate => :number, :default => 200
 
-    config :ssl_certificate_validation, :deprecated => "This never worked correctly and is now deprecated and a noop"
+    config :ssl_certificate_validation, :obsolete  => "This option is obsolete as it never worked correctly."
 
     # If you need to use a custom X.509 CA (.pem certs) specify the path to that here
     config :cacert, :validate => :path

--- a/logstash-mixin-http_client.gemspec
+++ b/logstash-mixin-http_client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-http_client'
-  s.version         = '5.2.1'
+  s.version         = '6.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "AWS mixins to provide a unified interface for Amazon Webservice"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This bumps the mixin up a major version number, which means plugins that use this mixin will also require a major version bump and a dependency on >= 6.0.0 of this mixin

This change also has implication in the documentation of plugins using this mixin