### PR TITLE
Let user set whether to do eager authentication

### DIFF
--- a/lib/logstash/plugin_mixins/http_client.rb
+++ b/lib/logstash/plugin_mixins/http_client.rb
@@ -98,6 +98,12 @@ module LogStash::PluginMixins::HttpClient
 
     # Password to use for HTTP auth
     config :password, :validate => :password
+
+    # Whether to instruct Manticore to present basic auth credentials on initial
+    # request, rather than being challenged for them. You should only use this
+    # if you have a specific need for it, as it may be a security concern otherwise.
+    # Currently defaults to true for backwards compatibility.
+    config :eager, :validate => :boolean, :default => true
   end
 
   public
@@ -132,7 +138,7 @@ module LogStash::PluginMixins::HttpClient
       c[:auth] = {
         :user => @user,
         :password => @password.value,
-        :eager => true
+        :eager => @eager
       }
     end
 


### PR DESCRIPTION
As discussed in https://github.com/logstash-plugins/logstash-input-http_poller/issues/87, this PR lets a user configure whether or not to do eager authentication.

I have left the default as true, although manticore upstream makes a case for using false by default.