### PR TITLE
remove obsolete ssl_certificate_verify option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.0.0
+  - Removed obsolete ssl_certificate_verify option
+
 ## 6.0.1
   - Fix some documentation issues
 

--- a/lib/logstash/plugin_mixins/http_client.rb
+++ b/lib/logstash/plugin_mixins/http_client.rb
@@ -52,8 +52,6 @@ module LogStash::PluginMixins::HttpClient
     # See https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.html#setValidateAfterInactivity(int)[these docs for more info]
     config :validate_after_inactivity, :validate => :number, :default => 200
 
-    config :ssl_certificate_validation, :obsolete  => "This option is obsolete as it never worked correctly."
-
     # If you need to use a custom X.509 CA (.pem certs) specify the path to that here
     config :cacert, :validate => :path
 

--- a/logstash-mixin-http_client.gemspec
+++ b/logstash-mixin-http_client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-http_client'
-  s.version         = '6.0.1'
+  s.version         = '7.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "AWS mixins to provide a unified interface for Amazon Webservice"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
