### PR TITLE
add lax_redirect setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.1.0
+  - Add: "lax_redirects" setting to redirect POST/DELETE
+
 ## 7.0.0
   - Removed obsolete ssl_certificate_verify option
 

--- a/lib/logstash/plugin_mixins/http_client.rb
+++ b/lib/logstash/plugin_mixins/http_client.rb
@@ -27,6 +27,9 @@ module LogStash::PluginMixins::HttpClient
     # Should redirects be followed? Defaults to `true`
     config :follow_redirects, :validate => :boolean, :default => true
 
+    # Allow POST and DELETE to also be redirected
+    config :lax_redirects, :validate => :boolean, :default => false
+
     # Max number of concurrent connections. Defaults to `50`
     config :pool_max, :validate => :number, :default => 50
 
@@ -175,7 +178,11 @@ module LogStash::PluginMixins::HttpClient
 
   private
   def make_client
-    Manticore::Client.new(client_config)
+    Manticore::Client.new(client_config) do |builder, _|
+      if @lax_redirects
+        builder.set_redirect_strategy org.apache.http.impl.client.LaxRedirectStrategy.new
+      end
+    end
   end
 
   public

--- a/logstash-mixin-http_client.gemspec
+++ b/logstash-mixin-http_client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-http_client'
-  s.version         = '7.0.0'
+  s.version         = '7.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "AWS mixins to provide a unified interface for Amazon Webservice"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The httpclient library used is very conservative when it comes to status code handling. According to RFC7231, only HEAD and GET requests should be automatically redirected. Others like POST should required user interaction (e.g. a browser dialog window).

However it is possible to customize redirect strategy to override this behavior and there's even a more Lax strategy..aptly named LaxRedirectStrategy. This strategy will only redirect HEAD/GET/DELETE/POST, but not PUT.

This PR adds an option to enable LaxRedirectStrategy. Logstash plugins that rely on this mixin will have the ability to set `lax_redirects => true` when using POST/DELETE methods.

To test this, instruct a local logstash to use this a local copy of this repo by editing the logstash's Gemfile:

```ruby
gem "logstash-mixin-http_client", :path => "/tmp/logstash-plugins/logstash-mixin-http_client"
```

With an endpoint that has a 307 redirect:

```ruby
require 'sinatra'

post "/foo/bar" do
  redirect "/test", 307
end

post "/test" do
  [200, {}, {}]
end
```
Then use a pipeline that does a POST:

```
bin/logstash -e "output { http { url => 'http://127.0.0.1:4567/foo/bar' lax_redirects => true http_method => post } }"
```

The sinatra app will show either 1 or 2 requests from Logstash depending on `lax_redirects` being false or true, respectively.