### PR TITLE
Feat: add ssl_verification_mode => 'full' / 'none'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,18 @@
 sudo: false
 language: ruby
 cache: bundler
-rvm:
-- jruby-1.7.25
-script: bundle exec rspec spec && bundle exec rspec spec --tag integration
+
+script: bundle exec rspec spec
 jdk: openjdk8
 matrix:
   include:
-  - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=master
-  - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=7.0
+  - rvm: jruby-9.2.20.1
+    env: LOGSTASH_BRANCH=8.0
+  - rvm: jruby-9.2.20.1
+    env: LOGSTASH_BRANCH=7.16
   - rvm: jruby-9.1.13.0
     env: LOGSTASH_BRANCH=6.7
-  - rvm: jruby-9.1.13.0
-    env: LOGSTASH_BRANCH=6.6
-  - rvm: jruby-1.7.27
-    env: LOGSTASH_BRANCH=5.6
+  - rvm: jruby-9.2.7.0
+    env: LOGSTASH_BRANCH=6.8
   fast_finish: true
 before_install: gem install bundler -v '< 2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 7.1.0
+  - Feat: add `ssl_verification_mode` [#39](https://github.com/logstash-plugins/logstash-mixin-http_client/pull/39) 
+
 ## 7.0.0
-  - Removed obsolete ssl_certificate_verify option
+  - Removed obsolete `ssl_certificate_verify` option
 
 ## 6.0.1
   - Fix some documentation issues

--- a/logstash-mixin-http_client.gemspec
+++ b/logstash-mixin-http_client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-http_client'
-  s.version         = '7.0.0'
+  s.version         = '7.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "AWS mixins to provide a unified interface for Amazon Webservice"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-mixin-http_client.gemspec
+++ b/logstash-mixin-http_client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'manticore', '>= 0.5.2', '< 1.0.0'
+  s.add_runtime_dependency 'manticore', '>= 0.8.0', '< 1.0.0'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'stud'

--- a/spec/plugin_mixin/http_client_spec.rb
+++ b/spec/plugin_mixin/http_client_spec.rb
@@ -85,7 +85,7 @@ describe LogStash::PluginMixins::HttpClient do
     end
   end
 
-describe "http auth" do
+  describe "http auth" do
     subject { Dummy.new(client_config).send(:client_config)[:auth] }
 
     let(:user) { "myuser" }
@@ -184,5 +184,36 @@ describe "http auth" do
 
       include_examples("raising a configuration error")
     end
+  end
+
+  describe "with verify mode" do
+    let(:file) { Stud::Temporary.file }
+    let(:path) { file.path }
+    after { File.unlink(path)}
+
+    context "default" do
+      let(:conf) { basic_config }
+
+      it "sets manticore verify" do
+        expect( Dummy.new(conf).client_config[:ssl] ).to include :verify => :strict
+      end
+    end
+
+    context "'full'" do
+      let(:conf) { basic_config.merge("ssl_verification_mode" => 'full') }
+
+      it "sets manticore verify" do
+        expect( Dummy.new(conf).client_config[:ssl] ).to include :verify => :strict
+      end
+    end
+
+    context "'none'" do
+      let(:conf) { basic_config.merge("ssl_verification_mode" => 'none') }
+
+      it "sets manticore verify" do
+        expect( Dummy.new(conf).client_config[:ssl] ).to include :verify => :disable
+      end
+    end
+
   end
 end

--- a/spec/plugin_mixin/http_client_spec.rb
+++ b/spec/plugin_mixin/http_client_spec.rb
@@ -194,7 +194,7 @@ describe LogStash::PluginMixins::HttpClient do
     context "default" do
       let(:conf) { basic_config }
 
-      it "sets manticore verify" do
+      it "sets manticore verify to :strict" do
         expect( Dummy.new(conf).client_config[:ssl] ).to include :verify => :strict
       end
     end

--- a/spec/plugin_mixin/http_client_spec.rb
+++ b/spec/plugin_mixin/http_client_spec.rb
@@ -202,7 +202,7 @@ describe LogStash::PluginMixins::HttpClient do
     context "'full'" do
       let(:conf) { basic_config.merge("ssl_verification_mode" => 'full') }
 
-      it "sets manticore verify" do
+      it "sets manticore verify to :strict" do
         expect( Dummy.new(conf).client_config[:ssl] ).to include :verify => :strict
       end
     end

--- a/spec/plugin_mixin/http_client_spec.rb
+++ b/spec/plugin_mixin/http_client_spec.rb
@@ -113,7 +113,7 @@ describe "http auth" do
     end
 
     context "with a user but no password specified" do
-      let(:client_config) { c = super; c.delete("password"); c }
+      let(:client_config) { c = super(); c.delete("password"); c }
 
       it "should raise a configuration error" do
         expect { subject }.to raise_error(::LogStash::ConfigurationError)

--- a/spec/plugin_mixin/http_client_spec.rb
+++ b/spec/plugin_mixin/http_client_spec.rb
@@ -210,7 +210,7 @@ describe LogStash::PluginMixins::HttpClient do
     context "'none'" do
       let(:conf) { basic_config.merge("ssl_verification_mode" => 'none') }
 
-      it "sets manticore verify" do
+      it "sets manticore verify to :disable" do
         expect( Dummy.new(conf).client_config[:ssl] ).to include :verify => :disable
       end
     end


### PR DESCRIPTION
Adds `ssl_verification_mode` configuration option, with the default being `'full'`.
Manticore wise, due backwards compatibility, the `'full'` option translates to `verify: :strict`.
This could be relaxed in the future (`verify: :browser`) but would need more investigation/implementation whether we could force SAN to be present in the server certificate (same way as ES/Beats implement *strict* verification).

---
closing https://github.com/logstash-plugins/logstash-mixin-http_client/pull/31 (alternate impl)
closing https://github.com/logstash-plugins/logstash-mixin-http_client/pull/34 (alternate impl)