### PR TITLE
Add support for SSL setting obsolescence to HTTP mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.5.0
+  - Adds new mixin configuration option `with_obsolete` to mark `ssl` options as obsolete
+
 ## 7.4.0
   - Adds new `ssl_enabled` setting for enabling/disabling the SSL configurations [#44](https://github.com/logstash-plugins/logstash-mixin-http_client/pull/44)
 

--- a/lib/logstash/plugin_mixins/http_client.rb
+++ b/lib/logstash/plugin_mixins/http_client.rb
@@ -19,8 +19,10 @@ module LogStash::PluginMixins::HttpClient
   end
 
   class Adapter < Module
-    def initialize(with_deprecated: false)
+    def initialize(with_deprecated: false, with_obsolete: false)
+       raise ArgumentError, "A plugin cannot support deprecated and obsolete SSL settings" if with_deprecated && with_obsolete
       @include_dep = with_deprecated
+      @include_obsolete = with_obsolete
     end
 
     def included(base)
@@ -28,7 +30,11 @@ module LogStash::PluginMixins::HttpClient
       if @include_dep
         require_relative 'http_client/deprecated_ssl_config_support'
         base.include(DeprecatedSslConfigSupport)
+      elsif @include_obsolete
+        require_relative 'http_client/obsolete_ssl_config_support'
+        base.include(ObsoleteSslConfigSupport)
       end
+
       nil
     end
   end

--- a/lib/logstash/plugin_mixins/http_client/obsolete_ssl_config_support.rb
+++ b/lib/logstash/plugin_mixins/http_client/obsolete_ssl_config_support.rb
@@ -3,9 +3,6 @@ module LogStash::PluginMixins::HttpClient
     def self.included(base)
       fail ArgumentError unless base <= LogStash::PluginMixins::HttpClient::Implementation
 
-      require 'logstash/plugin_mixins/normalize_config_support'
-      base.include(LogStash::PluginMixins::NormalizeConfigSupport)
-
       base.config :cacert, :obsolete => 'Use `ssl_certificate_authorities` instead'
       base.config :client_cert, :obsolete => 'Use `ssl_certificate` instead'
       base.config :client_key, :obsolete => 'Use `ssl_key` instead'

--- a/lib/logstash/plugin_mixins/http_client/obsolete_ssl_config_support.rb
+++ b/lib/logstash/plugin_mixins/http_client/obsolete_ssl_config_support.rb
@@ -1,0 +1,22 @@
+module LogStash::PluginMixins::HttpClient
+  module ObsoleteSslConfigSupport
+    def self.included(base)
+      fail ArgumentError unless base <= LogStash::PluginMixins::HttpClient::Implementation
+
+      require 'logstash/plugin_mixins/normalize_config_support'
+      base.include(LogStash::PluginMixins::NormalizeConfigSupport)
+
+      base.config :cacert, :obsolete => 'Use `ssl_certificate_authorities` instead'
+      base.config :client_cert, :obsolete => 'Use `ssl_certificate` instead'
+      base.config :client_key, :obsolete => 'Use `ssl_key` instead'
+      base.config :keystore, :obsolete => 'Use `ssl_keystore_path` instead'
+      base.config :keystore_type, :obsolete => 'Use `ssl_keystore_type` instead'
+      base.config :truststore, :obsolete => 'Use `ssl_truststore_path` instead'
+      base.config :truststore_type, :obsolete => 'Use `ssl_truststore_type` instead'
+
+      # Retain validation for password types to avoid inadvertent information disclosure
+      base.config :keystore_password, :validate => :password, :obsolete => 'Use `ssl_keystore_password` instead'
+      base.config :truststore_password, :validate => :password, :obsolete => 'Use `ssl_truststore_password` instead'
+    end
+  end
+end

--- a/logstash-mixin-http_client.gemspec
+++ b/logstash-mixin-http_client.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-mixin-http_client'
-  s.version         = '7.4.0'
+  s.version         = '7.5.0'
   s.licenses        = ['Apache License (2.0)']
-  s.summary         = "AWS mixins to provide a unified interface for Amazon Webservice"
+  s.summary         = "Mixin to provide consistent config deprecation and obsoletion across HTTP plugins"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elastic"]
   s.email           = 'info@elastic.co'

--- a/spec/plugin_mixin/http_client_ssl_spec.rb
+++ b/spec/plugin_mixin/http_client_ssl_spec.rb
@@ -46,8 +46,6 @@ end
 
 shared_examples 'an obsolete setting with guidance' do |deprecations_and_guidance|
 
-  let(:logger_stub) { double('Logger').as_null_object }
-
   deprecations_and_guidance.each do |obsolete_setting, canonical_setting_name|
     it "emits an error about the setting `#{obsolete_setting}` now being obsolete and provides guidance to use `#{canonical_setting_name}`" do
       error_text = /The setting `#{obsolete_setting}` in plugin `with_obsolete` is obsolete and is no longer available. Use `#{canonical_setting_name}` instead/i

--- a/spec/plugin_mixin/http_client_ssl_spec.rb
+++ b/spec/plugin_mixin/http_client_ssl_spec.rb
@@ -44,6 +44,18 @@ shared_examples 'a deprecated setting with guidance' do |deprecations_and_guidan
   end
 end
 
+shared_examples 'an obsolete setting with guidance' do |deprecations_and_guidance|
+
+  let(:logger_stub) { double('Logger').as_null_object }
+
+  deprecations_and_guidance.each do |obsolete_setting, canonical_setting_name|
+    it "emits an error about the setting `#{obsolete_setting}` now being obsolete and provides guidance to use `#{canonical_setting_name}`" do
+      error_text = /The setting `#{obsolete_setting}` in plugin `with_obsolete` is obsolete and is no longer available. Use `#{canonical_setting_name}` instead/i
+      expect { plugin_class.new(conf)}.to raise_error LogStash::ConfigurationError, error_text
+    end
+  end
+end
+
 shared_examples 'with common ssl options' do
   describe 'with verify mode' do
     let(:file) { Stud::Temporary.file }
@@ -141,6 +153,33 @@ shared_examples("raise an http config error") do |message|
     expect {
       plugin_class.new(conf).client_config
     }.to raise_error(LogStash::PluginMixins::HttpClient::InvalidHTTPConfigError, message)
+  end
+end
+
+shared_examples 'a client with obsolete ssl options' do
+  describe LogStash::PluginMixins::HttpClient do
+    let(:basic_config) { {} }
+    let(:impl) { plugin_class.new(basic_config) }
+    let(:use_deprecated_config) { true }
+
+    include_examples 'with common ssl options'
+
+    [{:name => 'cacert', :canonical_name => 'ssl_certificate_authorities'},
+     {:name => 'client_cert', :canonical_name => 'ssl_certificate'},
+     {:name => 'client_key', :canonical_name => 'ssl_key'},
+     {:name => "keystore", :canonical_name => 'ssl_keystore_path'},
+     {:name => 'truststore', :canonical_name => 'ssl_truststore_path'},
+     {:name => "keystore_password", :canonical_name => "ssl_keystore_password"},
+     {:name => 'truststore_password', :canonical_name => "ssl_truststore_password"},
+     {:name => "keystore_type", :canonical_name => "ssl_keystore_type"},
+     {:name => 'truststore_type', :canonical_name => 'ssl_truststore_type'}
+    ].each do |settings|
+      context "with option #{settings[:name]}" do
+        let(:conf) { basic_config.merge(settings[:name] => 'test_value') }
+
+        it_behaves_like('an obsolete setting with guidance', settings[:name] => settings[:canonical_name])
+      end
+    end
   end
 end
 
@@ -378,6 +417,11 @@ class PluginWithDeprecatedTrue < LogStash::Inputs::Base
   config_name 'with_deprecated'
 end
 
+class PluginWithObsoleteTrue < LogStash::Inputs::Base
+  include LogStash::PluginMixins::HttpClient[:with_obsolete => true]
+  config_name 'with_obsolete'
+end
+
 class PluginWithDeprecatedFalse < LogStash::Inputs::Base
   include LogStash::PluginMixins::HttpClient[:with_deprecated => false]
   config_name 'without_deprecated'
@@ -391,6 +435,10 @@ describe PluginWithNoModuleConfig do
   it 'includes DeprecatedSslConfigSupport module' do
     expect(plugin_class.ancestors).to include(LogStash::PluginMixins::HttpClient::DeprecatedSslConfigSupport)
   end
+
+  it 'does not include ObsoleteSslConfigSupport module' do
+    expect(plugin_class.ancestors).to_not include(LogStash::PluginMixins::HttpClient::ObsoleteSslConfigSupport)
+  end
 end
 
 describe PluginWithDeprecatedFalse do
@@ -401,10 +449,19 @@ describe PluginWithDeprecatedFalse do
   it 'does not include DeprecatedSslConfigSupport module' do
     expect(plugin_class.ancestors).to_not include(LogStash::PluginMixins::HttpClient::DeprecatedSslConfigSupport)
   end
+
+  it 'does not include ObsoleteSslConfigSupport module' do
+    expect(plugin_class.ancestors).to_not include(LogStash::PluginMixins::HttpClient::ObsoleteSslConfigSupport)
+  end
+
 end
 
 describe PluginWithDeprecatedTrue do
   let(:plugin_class) { PluginWithDeprecatedTrue }
+
+  it 'does not include ObsoleteSslConfigSupport module' do
+    expect(plugin_class.ancestors).to_not include(LogStash::PluginMixins::HttpClient::ObsoleteSslConfigSupport)
+  end
 
   it_behaves_like 'a client with deprecated ssl options'
 
@@ -461,4 +518,26 @@ describe PluginWithDeprecatedTrue do
   it 'includes DeprecatedSslConfigSupport module' do
     expect(plugin_class.ancestors).to include(LogStash::PluginMixins::HttpClient::DeprecatedSslConfigSupport)
   end
+end
+
+describe "PluginWithObsoleteAndDeprecatedTrue" do
+  it 'raises an error when trying to create a class with obsolete and deprecated both true' do
+    expect {
+      class PluginWithObsoleteAndDeprecatedTrue < LogStash::Inputs::Base
+        include LogStash::PluginMixins::HttpClient[:with_obsolete => true, :with_deprecated => true]
+        config_name 'with_obsolete_and_deprecated'
+    end }.to raise_error ArgumentError, "A plugin cannot support deprecated and obsolete SSL settings"
+  end
+end
+
+describe PluginWithObsoleteTrue do
+  let(:plugin_class) { PluginWithObsoleteTrue }
+
+  it 'includes ObsoleteSslConfigSupport module' do
+    expect(plugin_class.ancestors).to include(LogStash::PluginMixins::HttpClient::ObsoleteSslConfigSupport)
+  end
+
+  it_behaves_like 'a client with obsolete ssl options'
+
+  it_behaves_like 'a client with standardized ssl options'
 end


### PR DESCRIPTION
The HTTP Client mixin is used to provide support for common deprecated configuration settings across a number of HTTP-based plugins, including

`logstash-filter-http`, `logstash-output-http`, `logstash-input-http_poller` and `logstash-integration-logstash`.

This commit adds support for marking the SSL settings as obsolete across all of these plugins.

